### PR TITLE
Sprint FOV

### DIFF
--- a/lua/weapons/ls_base/client/camera.lua
+++ b/lua/weapons/ls_base/client/camera.lua
@@ -348,6 +348,10 @@ function SWEP:GetViewFOV()
 		return self.IronsightsFOV
 	end
 
+	if (not self.NoSprintFOV) and self:IsSprinting() then
+		return self.SprintFOV or 1.08
+	end
+	
 	return 1
 end
 

--- a/lua/weapons/ls_base/common/think.lua
+++ b/lua/weapons/ls_base/common/think.lua
@@ -12,6 +12,10 @@ function SWEP:Think()
 		self:CustomThink()
 	end
 
+	if self.DoSprintHoldType then 
+		self:SetHoldType( ( self:IsSprinting() and self:GetPassiveHoldType() ) or self.HoldType )
+	end
+	
 	if CLIENT then
 		self:SwayThink()
 	end


### PR DESCRIPTION
Tiny FOV increase while sprinting, can disable by adding SWEP.NoSprintFOV, or change the value with SWEP.SprintFOV